### PR TITLE
feat: phases 3–6 scaffolding + AI edit pipeline integration

### DIFF
--- a/.ai/schemas/edit_schema.json
+++ b/.ai/schemas/edit_schema.json
@@ -1,0 +1,34 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/schemas/edit-command.json",
+  "title": "AI Edit Command Contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "edit_id", "file_path", "edit_type", "created_at"],
+  "properties": {
+    "version": {"type": "string", "enum": ["1.0.0"]},
+    "edit_id": {"type": "string", "pattern": "^edit_[a-zA-Z0-9]{8}$"},
+    "file_path": {"type": "string", "pattern": "^[^\u0000<>:\"|?*]+$"},
+    "edit_type": {"type": "string", "enum": ["replace", "insert", "delete", "append", "prepend", "create_file"]},
+    "created_at": {"type": "string", "format": "date-time"},
+    "description": {"type": "string", "maxLength": 200},
+    "rationale": {"type": "string", "maxLength": 500},
+    "safety_checks": {"type": "object", "additionalProperties": false, "required": ["backup_required", "destructive"],
+      "properties": {"backup_required": {"type": "boolean"}, "destructive": {"type": "boolean"}, "affects_api": {"type": "boolean"}}},
+    "start_line": {"type": "integer", "minimum": 1},
+    "end_line": {"type": "integer", "minimum": 1},
+    "new_content": {"type": "string"},
+    "original_content": {"type": "string"},
+    "line_number": {"type": "integer", "minimum": 0},
+    "content": {"type": "string"},
+    "content_to_delete": {"type": "string"},
+    "permissions": {"type": "string", "pattern": "^[0-7]{3}$"}
+  },
+  "allOf": [
+    {"if": {"properties": {"edit_type": {"const": "replace"}}}, "then": {"required": ["start_line", "end_line", "new_content"]}},
+    {"if": {"properties": {"edit_type": {"const": "insert"}}}, "then": {"required": ["line_number", "content"]}},
+    {"if": {"properties": {"edit_type": {"const": "delete"}}}, "then": {"required": ["start_line", "end_line"]}},
+    {"if": {"properties": {"edit_type": {"enum": ["append", "prepend"]}}}, "then": {"required": ["content"]}},
+    {"if": {"properties": {"edit_type": {"const": "create_file"}}}, "then": {"required": ["content"]}}
+  ]
+}

--- a/.ai/schemas/plan.schema.json
+++ b/.ai/schemas/plan.schema.json
@@ -1,0 +1,11 @@
+﻿{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AI Edit Plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["edits"],
+  "properties": {
+    "metadata": {"type": "object", "additionalProperties": true},
+    "edits": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": true}}
+  }
+}

--- a/.ai/workflows/AI_EDIT_PIPELINE.yaml
+++ b/.ai/workflows/AI_EDIT_PIPELINE.yaml
@@ -1,0 +1,3 @@
+﻿name: AI Edit Pipeline (Plan-Aware)
+version: "1.1.0"
+steps: []

--- a/scripts/generate_models.py
+++ b/scripts/generate_models.py
@@ -1,0 +1,100 @@
+﻿#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMAS_DIR = ROOT / 'contracts' / 'schemas'
+OUT_DIR = ROOT / 'src' / 'contracts' / 'generated'
+
+def snake_to_pascal(s: str) -> str:
+    parts = re.split(r"[^A-Za-z0-9]+", s)
+    return ''.join(p[:1].upper() + p[1:] for p in parts if p)
+
+def filename_to_classname(p: Path, fallback: str = 'Model') -> str:
+    name = p.stem
+    return snake_to_pascal(name) or fallback
+
+def map_type(prop: Dict[str, Any]) -> str:
+    t = prop.get('type')
+    if isinstance(t, list):
+        if 'null' in t and len(t) > 1:
+            t = [x for x in t if x != 'null'][0]
+        else:
+            t = t[0]
+    if t == 'string':
+        return 'str'
+    if t == 'integer':
+        return 'int'
+    if t == 'number':
+        return 'float'
+    if t == 'boolean':
+        return 'bool'
+    if t == 'array':
+        item_t = map_type(prop.get('items', {})) if isinstance(prop.get('items'), dict) else 'Any'
+        return f'List[{item_t}]'
+    if t == 'object':
+        ap = prop.get('additionalProperties')
+        if ap is False:
+            return 'Dict[str, Any]'
+        if isinstance(ap, dict):
+            return f'Dict[str, {map_type(ap)}]'
+        return 'Dict[str, Any]'
+    return 'Any'
+
+def generate_model(schema_path: Path) -> tuple[str, str]:
+    schema = json.loads(schema_path.read_text(encoding='utf-8'))
+    title = schema.get('title') or filename_to_classname(schema_path)
+    classname = snake_to_pascal(title)
+    props = schema.get('properties', {})
+    required: List[str] = list(schema.get('required', []))
+    addl = schema.get('additionalProperties', True)
+
+    imports = [
+        'from __future__ import annotations',
+        'from typing import Any, Dict, List, Optional',
+        'from pydantic import BaseModel, Field',
+    ]
+
+    fields: List[str] = []
+    for name, spec in props.items():
+        py_t = map_type(spec)
+        is_required = name in required
+        ann = py_t if is_required else f'Optional[{py_t}]'
+        default = '...' if is_required else 'None'
+        descr = spec.get('description')
+        field_expr = f'Field({default})' if not descr else f"Field({default}, description={json.dumps(descr)})"
+        fields.append(f"    {name}: {ann} = {field_expr}")
+
+    forbid = addl is False
+    config = "    class Config:\n        extra = 'forbid'\n" if forbid else ''
+
+    body = [
+        *imports,
+        '',
+        f'class {classname}(BaseModel):',
+        f"    " + (schema.get('description') or f'Generated from {schema_path.name}'),
+        *(fields or ['    pass']),
+        '',
+        config,
+    ]
+    content = '\n'.join([line for line in body if line is not None])
+    return classname, content
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    modules: List[str] = []
+    for sp in sorted(SCHEMAS_DIR.glob('*.json')):
+        classname, code = generate_model(sp)
+        out_path = OUT_DIR / f'{classname}.py'
+        out_path.write_text(code, encoding='utf-8')
+        modules.append(classname)
+        print(f'generated: {out_path}')
+    (OUT_DIR / '__init__.py').write_text('\n'.join(['# Auto-generated; do not edit by hand', '', *[f"from .{m} import {m}" for m in modules]]) + '\n', encoding='utf-8')
+    print(f'generated {len(modules)} module(s)')
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/apply_edits.py
+++ b/tools/apply_edits.py
@@ -1,0 +1,168 @@
+﻿#!/usr/bin/env python3
+"""
+Deterministic edit applier for AI Edit Plans.
+Safe path handling, checksum verification, and bottom-up range application.
+
+Notes:
+- Accepts either a plan object with `edits` or a raw list of edits.
+- For insert/append/prepend/create_file, supports `content` (preferred) or `new_content` (alias).
+- Insert supports line_number==0 as beginning of file; otherwise 1-indexed.
+"""
+import json
+from pathlib import Path
+from typing import List, Dict, Any, Tuple
+import re
+import sys
+
+
+def _norm_sep(s: str) -> str:
+    return s.replace("\\", "/")
+
+
+def _safe_path(raw: str) -> Path:
+    raw_s = raw or ""
+    if Path(raw_s).is_absolute() or raw_s.startswith("/"):
+        raise ValueError(f"Unsafe absolute path: {raw_s}")
+    if re.match(r"^[A-Za-z]:[\\/]", raw_s):
+        raise ValueError(f"Unsafe drive-qualified path: {raw_s}")
+    parts = _norm_sep(raw_s).split("/")
+    if ".." in parts:
+        raise ValueError(f"Path traversal not allowed: {raw_s}")
+    return Path(raw_s)
+
+
+def _sha256_bytes(b: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(b).hexdigest()
+
+
+def _split_lines(text: str) -> List[str]:
+    return text.splitlines(keepends=True)
+
+
+def _apply_to_file(file_path: Path, edits: List[Dict[str, Any]], checksum_expected: str | None = None) -> Tuple[int, int]:
+    created = 0
+    modified = 0
+    exists = file_path.exists()
+
+    if checksum_expected and exists:
+        actual = _sha256_bytes(file_path.read_bytes())
+        if actual.lower() != checksum_expected.lower():
+            raise RuntimeError(f"Checksum mismatch for {file_path}")
+
+    creates = [e for e in edits if e.get("edit_type") == "create_file"]
+    non_creates = [e for e in edits if e.get("edit_type") != "create_file"]
+
+    if creates:
+        if exists:
+            raise RuntimeError(f"{file_path} already exists; create_file not allowed")
+        content = ""
+        for e in creates:
+            c = e.get("content") or e.get("new_content") or ""
+            if c:
+                content = c
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content, encoding="utf-8")
+        exists = True
+        created += 1
+
+    if non_creates:
+        if not exists:
+            raise RuntimeError(f"{file_path} not found for non-create edits")
+        lines = _split_lines(file_path.read_text(encoding="utf-8"))
+
+        ranges = []
+        for e in non_creates:
+            et = e.get("edit_type")
+            if et in ("replace", "delete"):
+                s = int(e["start_line"]) - 1
+                e_ = int(e["end_line"]) - 1
+                ranges.append((s, e_, e))
+            elif et == "insert":
+                ln = int(e["line_number"])  # 0 means beginning
+                idx = 0 if ln == 0 else ln - 1
+                ranges.append((idx, idx - 1, e))
+            elif et == "append":
+                ranges.append((len(lines), len(lines) - 1, e))
+            elif et == "prepend":
+                ranges.append((0, -1, e))
+
+        ranges.sort(key=lambda t: (t[0], t[1]), reverse=True)
+
+        for s_idx, e_idx, e in ranges:
+            et = e.get("edit_type")
+            if et in ("replace", "delete"):
+                orig = e.get("original_content")
+                current = "".join(lines[s_idx : e_idx + 1])
+                if orig is not None and current != orig:
+                    raise RuntimeError(
+                        f"original_content mismatch in {file_path} for lines {s_idx+1}-{e_idx+1}"
+                    )
+                if et == "replace":
+                    newc = e.get("new_content", "")
+                    new_lines = _split_lines(newc)
+                    lines[s_idx : e_idx + 1] = new_lines
+                else:
+                    del lines[s_idx : e_idx + 1]
+            elif et == "insert":
+                payload = e.get("content") or e.get("new_content", "")
+                new_lines = _split_lines(payload)
+                insert_at = s_idx
+                lines[insert_at:insert_at] = new_lines
+            elif et == "append":
+                payload = e.get("content") or e.get("new_content", "")
+                new_lines = _split_lines(payload)
+                lines.extend(new_lines)
+            elif et == "prepend":
+                payload = e.get("content") or e.get("new_content", "")
+                new_lines = _split_lines(payload)
+                lines[0:0] = new_lines
+
+        file_path.write_text("".join(lines), encoding="utf-8")
+        modified += 1
+
+    return created, modified
+
+
+def _load_obj(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python tools/apply_edits.py <plan_or_edits.json>")
+        return 1
+    obj = _load_obj(Path(sys.argv[1]))
+    if isinstance(obj, dict) and "edits" in obj:
+        edits = obj["edits"]
+        meta = obj.get("metadata", {})
+    elif isinstance(obj, list):
+        edits = obj
+        meta = {}
+    else:
+        raise ValueError("Input must be list or object with 'edits'.")
+
+    by_file: Dict[str, List[Dict[str, Any]]] = {}
+    for e in edits:
+        fp = str(e.get("file_path", "")).strip()
+        target = _safe_path(fp)
+        by_file.setdefault(str(target), []).append(e)
+
+    created_total = 0
+    modified_total = 0
+    checksums = (meta or {}).get("pre_edit_checksums") or {}
+    for rel, e_list in by_file.items():
+        created, modified = _apply_to_file(Path(rel), e_list, checksums.get(rel))
+        created_total += created
+        modified_total += modified
+
+    report = {"created_files": created_total, "modified_files": modified_total, "total_edits": len(edits)}
+    print(json.dumps({"status": "ok", "report": report}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tools/edit_validator_v2.py
+++ b/tools/edit_validator_v2.py
@@ -1,0 +1,230 @@
+﻿#!/usr/bin/env python3
+"""
+Edit Plan/Batch Validator v2
+- Accepts either a list[edit] or an object {"edits":[...], "metadata":{...}}
+- Hardens path safety (no absolute paths, no drive letters, no '..')
+- Adjusts conflict detection to allow adjacency (no error when ranges touch)
+- Optionally verifies per-edit or plan-level pre_edit_checksum (if present)
+"""
+import json
+import re
+from pathlib import Path
+from typing import List, Dict, Any, Tuple
+from datetime import datetime
+import hashlib
+
+try:
+    import jsonschema
+except Exception:
+    jsonschema = None
+
+
+class EditValidatorV2:
+    def __init__(self, schema_path: str = ".ai/schemas/edit_schema.json", plan_schema_path: str = ".ai/schemas/plan.schema.json"):
+        self.schema_path = schema_path
+        self.plan_schema_path = plan_schema_path
+        self._edit_schema = None
+        self._plan_schema = None
+        if jsonschema is not None:
+            with open(self.schema_path, "r", encoding="utf-8-sig") as f:
+                self._edit_schema = json.load(f)
+            try:
+                with open(self.plan_schema_path, "r", encoding="utf-8-sig") as f:
+                    self._plan_schema = json.load(f)
+            except FileNotFoundError:
+                self._plan_schema = None
+            # Inline item schema to avoid $ref resolution issues
+            if self._plan_schema and "properties" in self._plan_schema and "edits" in self._plan_schema["properties"]:
+                try:
+                    if isinstance(self._plan_schema["properties"]["edits"].get("items"), dict) and "$ref" in self._plan_schema["properties"]["edits"]["items"]:
+                    self._plan_schema["properties"]["edits"]["items"] = self._edit_schema
+                except Exception:
+                    pass
+
+    def load_edits(self, obj: Any) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        if isinstance(obj, list):
+            return obj, {}
+        if isinstance(obj, dict) and "edits" in obj and isinstance(obj["edits"], list):
+            return obj["edits"], obj.get("metadata", {}) or {}
+        raise ValueError("Input must be a list of edits or an object with an 'edits' array.")
+
+    def validate_against_schema(self, obj: Any) -> Tuple[bool, List[str]]:
+        if jsonschema is None:
+            return True, []
+        errors = []
+        if self._plan_schema and isinstance(obj, dict):
+            validator = jsonschema.Draft202012Validator(self._plan_schema)
+            for err in sorted(validator.iter_errors(obj), key=lambda e: e.path):
+                errors.append(self._format_schema_error(err))
+            return len(errors) == 0, errors
+        else:
+            validator = jsonschema.Draft202012Validator(self._edit_schema)
+            if isinstance(obj, list):
+                for i, edit in enumerate(obj):
+                    for err in sorted(validator.iter_errors(edit), key=lambda e: e.path):
+                        errors.append(f"[{i}] " + self._format_schema_error(err))
+                return len(errors) == 0, errors
+            elif isinstance(obj, dict) and "edits" in obj:
+                for i, edit in enumerate(obj["edits"]):
+                    for err in sorted(validator.iter_errors(edit), key=lambda e: e.path):
+                        errors.append(f"[edits[{i}]] " + self._format_schema_error(err))
+                return len(errors) == 0, errors
+            else:
+                return False, ["Input was neither a list nor a plan object"]
+
+    def validate_business_rules(self, edits: List[Dict[str, Any]], metadata: Dict[str, Any]) -> List[str]:
+        errors = []
+        errors += self._validate_file_safety(edits)
+        errors += self._validate_line_consistency(edits)
+        errors += self._validate_edit_conflicts(edits)
+        errors += self._validate_content_integrity(edits)
+        errors += self._validate_pre_edit_checksums(edits, metadata)
+        return errors
+
+    def generate_report(self, obj: Any) -> Dict[str, Any]:
+        edits, metadata = self.load_edits(obj)
+        schema_ok, schema_errors = self.validate_against_schema(obj)
+        business_errors = self.validate_business_rules(edits, metadata)
+
+        is_valid = schema_ok and (len(business_errors) == 0)
+        all_errors = []
+        if not schema_ok:
+            all_errors += [f"SCHEMA: {e}" for e in schema_errors]
+        all_errors += [f"RULE: {e}" for e in business_errors]
+
+        file_stats = self._build_file_stats(edits)
+
+        return {
+            "validation": {"is_valid": is_valid, "error_count": len(all_errors), "errors": all_errors},
+            "summary": {
+                "total_edits": len(edits),
+                "files_affected": len(file_stats),
+                "edit_types": sorted(list(set(edit.get("edit_type") for edit in edits))),
+                "file_stats": file_stats,
+            },
+            "signatures": [self.create_edit_signature(edit) for edit in edits],
+            "validated_at": datetime.utcnow().isoformat() + "Z",
+        }
+
+    def _validate_file_safety(self, edits: List[Dict[str, Any]]) -> List[str]:
+        errors = []
+        for edit in edits:
+            raw = str(edit.get("file_path", ""))
+            p = Path(raw)
+            if p.is_absolute() or raw.startswith("/"):
+                errors.append(f"Absolute paths not allowed: {raw}")
+            if re.match(r"^[A-Za-z]:[\\/]", raw):
+                errors.append(f"Drive-qualified path not allowed: {raw}")
+            parts = raw.replace("\\", "/").split("/")
+            if ".." in parts:
+                errors.append(f"Path traversal not allowed: {raw}")
+        return errors
+
+    def _validate_line_consistency(self, edits: List[Dict[str, Any]]) -> List[str]:
+        errors = []
+        for i, edit in enumerate(edits):
+            et = edit.get("edit_type")
+            if et in ("replace", "delete"):
+                s, e = edit.get("start_line"), edit.get("end_line")
+                if not isinstance(s, int) or not isinstance(e, int) or s < 1 or e < s:
+                    errors.append(f"[{i}] invalid start/end_line: {s}, {e}")
+            elif et == "insert":
+                line = edit.get("line_number")
+                if not isinstance(line, int) or line < 0:
+                    errors.append(f"[{i}] invalid line_number: {line}")
+        return errors
+
+    def _validate_edit_conflicts(self, edits: List[Dict[str, Any]]) -> List[str]:
+        errors = []
+        by_file: Dict[str, List[Tuple[int, int, int, str]]] = {}
+        for idx, edit in enumerate(edits):
+            f = edit.get("file_path")
+            et = edit.get("edit_type")
+            if et in ("replace", "delete"):
+                s, e = edit.get("start_line", 0), edit.get("end_line", 0)
+            elif et == "insert":
+                ln = edit.get("line_number", 0)
+                s = e = 0 if ln == 0 else ln
+            else:
+                continue
+            by_file.setdefault(f, []).append((s, e, idx, et))
+
+        for f, ranges in by_file.items():
+            ranges.sort()
+            for (cs, ce, ci, ct), (ns, ne, ni, nt) in zip(ranges, ranges[1:]):
+                if ce > ns:
+                    errors.append(
+                        f"Conflicting edits on {f}: [{ci}:{ct} {cs}-{ce}] overlaps [{ni}:{nt} {ns}-{ne}]"
+                    )
+        return errors
+
+    def _validate_content_integrity(self, edits: List[Dict[str, Any]]) -> List[str]:
+        errors = []
+        for i, edit in enumerate(edits):
+            et = edit.get("edit_type")
+            if et in ("replace", "delete"):
+                if not edit.get("original_content"):
+                    errors.append(f"[{i}] original_content is required for replace/delete")
+            for key in ("new_content", "content"):
+                if key in edit and isinstance(edit[key], str):
+                    if any(len(line) > 12000 for line in edit[key].splitlines()):
+                        errors.append(f"[{i}] {key} contains an unusually long line (>12k chars)")
+        return errors
+
+    def _validate_pre_edit_checksums(self, edits: List[Dict[str, Any]], metadata: Dict[str, Any]) -> List[str]:
+        errors = []
+        checksum_map = metadata.get("pre_edit_checksums") or {}
+        for i, e in enumerate(edits):
+            expected = e.get("pre_edit_checksum") or checksum_map.get(e.get("file_path"))
+            if expected:
+                path = Path(e.get("file_path"))
+                if not path.exists():
+                    errors.append(f"[{i}] checksum provided but file missing: {path}")
+                    continue
+                data = path.read_bytes()
+                actual = hashlib.sha256(data).hexdigest()
+                if actual.lower() != str(expected).lower():
+                    errors.append(f"[{i}] pre_edit_checksum mismatch for {path}")
+        return errors
+
+    def create_edit_signature(self, edit: Dict[str, Any]) -> str:
+        m = hashlib.sha256()
+        payload = "|".join(str(edit.get(k, "")) for k in ("edit_id", "file_path", "edit_type", "created_at"))
+        m.update(payload.encode("utf-8"))
+        return m.hexdigest()
+
+    def _build_file_stats(self, edits: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+        stats: Dict[str, Dict[str, Any]] = {}
+        for e in edits:
+            f = e.get("file_path", "")
+            stats.setdefault(f, {"count": 0, "types": set()})
+            stats[f]["count"] += 1
+            stats[f]["types"].add(e.get("edit_type"))
+        for s in stats.values():
+            s["types"] = sorted(list(s["types"]))
+        return stats
+
+    def _format_schema_error(self, err) -> str:
+        loc = "$" + "".join(f"[{repr(p)}]" if isinstance(p, int) else f".{p}" for p in err.absolute_path)
+        return f"{loc}: {err.message}"
+
+
+def _load_json(path: str):
+    with open(path, "r", encoding="utf-8-sig") as f:
+        return json.load(f)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print("Usage: python tools/edit_validator_v2.py <plan_or_edits.json>")
+        sys.exit(1)
+    obj = _load_json(sys.argv[1])
+    v = EditValidatorV2()
+    report = v.generate_report(obj)
+    print(json.dumps(report))
+    sys.exit(0 if report["validation"]["is_valid"] else 2)
+
+
+

--- a/tools/selfcheck_apply_edits.py
+++ b/tools/selfcheck_apply_edits.py
@@ -1,0 +1,50 @@
+﻿#!/usr/bin/env python3
+import json
+import hashlib
+import pathlib
+import subprocess
+import sys
+
+def run(cmd):
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.returncode, p.stdout, p.stderr
+
+def main():
+    root = pathlib.Path(__file__).resolve().parents[1]
+    tmp = root / "artifacts" / "_selfcheck"
+    tmp.mkdir(parents=True, exist_ok=True)
+    f = tmp / "hello.txt"
+    f.write_text("a\nB\nc\n", encoding="utf-8")
+    sha = hashlib.sha256(f.read_bytes()).hexdigest()
+    plan = {
+        "metadata": {"pre_edit_checksums": {"artifacts/_selfcheck/hello.txt": sha}},
+        "edits": [
+            {
+                "version": "1.0.0",
+                "edit_id": "edit_DEMO0001",
+                "file_path": "artifacts/_selfcheck/hello.txt",
+                "edit_type": "replace",
+                "start_line": 2,
+                "end_line": 2,
+                "original_content": "B\n",
+                "new_content": "b\n",
+                "created_at": "2025-01-01T00:00:00Z",
+            }
+        ],
+    }
+    plan_path = tmp / "plan.json"
+    plan_path.write_text(json.dumps(plan), encoding="utf-8")
+    code, out, err = run([sys.executable, str(root / "tools" / "edit_validator_v2.py"), str(plan_path)])
+    if code != 0:
+        print("validator failed", out, err)
+        return code
+    code, out, err = run([sys.executable, str(root / "tools" / "apply_edits.py"), str(plan_path)])
+    if code != 0:
+        print("applier failed", out, err)
+        return code
+    assert f.read_text(encoding="utf-8") == "a\nb\nc\n"
+    print("selfcheck ok")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR scaffolds Phase 3–6 foundations and integrates the AI Edit Pipeline.

Highlights
- Phase 3 (contracts):
  - contracts/schemas sample + generator (scripts/generate_models.py)
  - generated Pydantic models under src/contracts/generated/
  - new CLI: `cli-orchestrator codegen-models`
- AI Edit Pipeline:
  - .ai/schemas (edit/plan/APF IO) + .ai/workflows
  - tools/apply_edits.py, tools/edit_validator_v2.py, selfcheck script
  - CI: .github/workflows/ai_edit_validation.yml (self-contained)
- Router fix: add deterministic alternative mapping helper

Linked Issues
- Phase 3: #16 #17 #18
- Phase 4: #19 #20 #21
- Phase 5: #22 #23 #24
- Phase 6: #25 #26 #27 #28

Notes
- Tests remain green subject to pre-existing test failures unrelated to this change.
- No secrets required; validation workflow uses repo-local tools.