### PR TITLE
feat(coordination): add CLI group, persistence, dashboard/report/history; VerifierAdapter; config defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,7 @@ combined_repo_plan.composed.json
 config/*.pem
 !config/*.pem.template
 
+
+# Coordination state artifacts
+state/
+

--- a/src/cli_multi_rapid/adapters/verifier_adapter.py
+++ b/src/cli_multi_rapid/adapters/verifier_adapter.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Verifier Adapter
+
+Wraps the Verifier service as a deterministic adapter so workflows can
+invoke quality gates and schema checks via the routing system.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .base_adapter import AdapterResult, AdapterType, BaseAdapter
+from ..verifier import Verifier, GateResult
+
+
+class VerifierAdapter(BaseAdapter):
+    """Adapter exposing artifact verification and gate checks."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="verifier",
+            adapter_type=AdapterType.DETERMINISTIC,
+            description="Artifact/schema verification and quality gate checks",
+        )
+        self._verifier = Verifier()
+
+    def execute(
+        self,
+        step: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+        files: Optional[str] = None,
+    ) -> AdapterResult:
+        self._log_execution_start(step)
+
+        try:
+            params = self._extract_with_params(step)
+            op = params.get("operation") or params.get("op") or "check_gates"
+            emit_paths = self._extract_emit_paths(step)
+
+            if op == "verify_artifact":
+                artifact = params.get("artifact")
+                schema = params.get("schema")
+                if not artifact:
+                    return AdapterResult(success=False, error="Missing 'artifact' parameter")
+
+                artifact_path = Path(artifact)
+                schema_path = Path(schema) if schema else None
+                ok = self._verifier.verify_artifact(artifact_path, schema_path)
+
+                # Optionally emit a simple verification report
+                artifacts: List[str] = []
+                if emit_paths:
+                    report = {
+                        "operation": "verify_artifact",
+                        "artifact": str(artifact_path),
+                        "schema": str(schema_path) if schema_path else None,
+                        "valid": ok,
+                    }
+                    for p in emit_paths:
+                        out = Path(p)
+                        out.parent.mkdir(parents=True, exist_ok=True)
+                        with out.open("w", encoding="utf-8") as f:
+                            json.dump(report, f, indent=2)
+                        artifacts.append(str(out))
+
+                result = AdapterResult(
+                    success=ok,
+                    tokens_used=0,
+                    artifacts=artifacts,
+                    output="artifact valid" if ok else "artifact invalid",
+                    metadata={"operation": op, "valid": ok},
+                )
+                self._log_execution_complete(result)
+                return result
+
+            elif op == "check_gates":
+                gates = params.get("gates") or []
+                artifacts_dir = Path(params.get("artifacts_dir", "artifacts"))
+                if not isinstance(gates, list):
+                    return AdapterResult(success=False, error="'gates' must be a list")
+
+                results: List[GateResult] = self._verifier.check_gates(gates, artifacts_dir)
+                passed = all(r.passed for r in results)
+
+                # Build summary and optionally emit
+                summary = {
+                    "operation": "check_gates",
+                    "passed": passed,
+                    "results": [asdict(r) for r in results],
+                }
+                artifacts: List[str] = []
+                if emit_paths:
+                    for p in emit_paths:
+                        out = Path(p)
+                        out.parent.mkdir(parents=True, exist_ok=True)
+                        with out.open("w", encoding="utf-8") as f:
+                            json.dump(summary, f, indent=2)
+                        artifacts.append(str(out))
+
+                result = AdapterResult(
+                    success=passed,
+                    tokens_used=0,
+                    artifacts=artifacts,
+                    output="all gates passed" if passed else "one or more gates failed",
+                    metadata=summary,
+                )
+                self._log_execution_complete(result)
+                return result
+
+            else:
+                return AdapterResult(
+                    success=False,
+                    error=f"Unknown operation: {op}",
+                    metadata={"operation": op},
+                )
+
+        except Exception as e:
+            return AdapterResult(
+                success=False,
+                error=f"Verifier operation failed: {e}",
+                metadata={"exception_type": type(e).__name__},
+            )
+
+    def validate_step(self, step: Dict[str, Any]) -> bool:
+        params = self._extract_with_params(step)
+        op = params.get("operation") or params.get("op")
+        if op == "verify_artifact":
+            return bool(params.get("artifact"))
+        if op == "check_gates" or op is None:
+            return True
+        return False
+
+    def estimate_cost(self, step: Dict[str, Any]) -> int:
+        # Deterministic operations only
+        return 0
+
+    def is_available(self) -> bool:
+        # Always available; relies on local JSON and files
+        return True
+

--- a/src/cli_multi_rapid/config/coordination.py
+++ b/src/cli_multi_rapid/config/coordination.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Coordination Config Loader
+
+Loads optional coordination defaults from `.ai/config/coordination.yaml` with
+safe fallbacks if the file or fields are missing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+@dataclass
+class CoordinationConfig:
+    default_mode: str = "parallel"
+    max_parallel_workflows: int = 5
+    default_budget: float = 30.0
+    timeout_minutes: int = 60
+
+    # Resource limits (not enforced here; used by caller)
+    max_memory_mb: int = 2048
+    max_cpu_percent: int = 80
+    max_file_handles: int = 1000
+
+    # Retry policy
+    retry_max_attempts: int = 3
+    retry_backoff_seconds: tuple = (1, 5, 15)
+
+    # Security
+    security_level: str = "medium"
+    isolation_enabled: bool = True
+    network_access: bool = False
+
+
+def _read_yaml(path: Path) -> Dict[str, Any]:
+    try:
+        if not path.exists():
+            return {}
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+            return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def load_coordination_config(cwd: Optional[Path] = None) -> CoordinationConfig:
+    base = Path.cwd() if cwd is None else cwd
+    cfg_path = base / ".ai" / "config" / "coordination.yaml"
+    data = _read_yaml(cfg_path).get("coordination", {})
+
+    cfg = CoordinationConfig()
+
+    # Map known fields with safe conversions
+    cfg.default_mode = str(data.get("default_mode", cfg.default_mode))
+    cfg.max_parallel_workflows = int(
+        data.get("max_parallel_workflows", cfg.max_parallel_workflows)
+    )
+    cfg.default_budget = float(data.get("default_budget", cfg.default_budget))
+    cfg.timeout_minutes = int(data.get("timeout_minutes", cfg.timeout_minutes))
+
+    # Resource limits
+    rl = data.get("resource_limits", {}) or {}
+    cfg.max_memory_mb = int(rl.get("max_memory_mb", cfg.max_memory_mb))
+    cfg.max_cpu_percent = int(rl.get("max_cpu_percent", cfg.max_cpu_percent))
+    cfg.max_file_handles = int(rl.get("max_file_handles", cfg.max_file_handles))
+
+    # Retry policy
+    rp = data.get("retry_policy", {}) or {}
+    cfg.retry_max_attempts = int(rp.get("max_attempts", cfg.retry_max_attempts))
+    backoff = rp.get("backoff_seconds", list(cfg.retry_backoff_seconds))
+    try:
+        cfg.retry_backoff_seconds = tuple(int(x) for x in backoff)
+    except Exception:
+        pass
+
+    # Security
+    sec = data.get("security", {}) or {}
+    cfg.security_level = str(sec.get("default_level", cfg.security_level))
+    cfg.isolation_enabled = bool(sec.get("isolation_enabled", cfg.isolation_enabled))
+    cfg.network_access = bool(sec.get("network_access", cfg.network_access))
+
+    return cfg
+

--- a/src/cli_multi_rapid/main.py
+++ b/src/cli_multi_rapid/main.py
@@ -8,7 +8,7 @@ CLI orchestrator that routes between deterministic tools and AI agents.
 
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List, Dict, Any
 
 import typer
 from rich.console import Console
@@ -187,6 +187,411 @@ def run_ipt_wt(
         console.print("[red]Workflow runner not available[/red]")
         raise typer.Exit(code=1)
 
+
+# Coordination command group
+coordination_app = typer.Typer(
+    name="coordination", help="Multi-agent workflow coordination commands"
+)
+app.add_typer(coordination_app, name="coordination")
+
+
+def _ensure_state_dir() -> Path:
+    state_dir = Path("state/coordination")
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def _json_default(o: Any):
+    try:
+        import enum
+
+        if isinstance(o, enum.Enum):
+            return o.value
+    except Exception:
+        pass
+    try:
+        from dataclasses import asdict, is_dataclass
+
+        if is_dataclass(o):
+            return asdict(o)
+    except Exception:
+        pass
+    if isinstance(o, (Path,)):
+        return str(o)
+    return str(o)
+
+
+@coordination_app.command("run")
+def coordination_run(
+    workflows: List[Path] = typer.Argument(
+        ..., help="Workflow YAML files to coordinate"
+    ),
+    mode: str = typer.Option("parallel", "--mode", help="Coordination mode"),
+    max_parallel: int = typer.Option(3, "--max-parallel", help="Max parallel workflows"),
+    budget: float = typer.Option(50.0, "--budget", help="Total budget in USD"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show plan without executing"),
+):
+    """Run coordinated multi-workflow execution."""
+    console.print("[bold blue]Running coordinated workflows[/bold blue]")
+    console.print(f"[dim]Mode={mode}, MaxParallel={max_parallel}, Budget=${budget:.2f}, DryRun={dry_run}[/dim]")
+
+    try:
+        # Load defaults from coordination config (override only if still defaults)
+        from .config.coordination import load_coordination_config
+
+        cfg = load_coordination_config()
+        # If user did not change defaults, adopt config values
+        if mode == "parallel" and cfg.default_mode:
+            mode = cfg.default_mode
+        if max_parallel == 3 and cfg.max_parallel_workflows:
+            max_parallel = cfg.max_parallel_workflows
+        if abs(budget - 50.0) < 1e-9 and cfg.default_budget:
+            budget = cfg.default_budget
+
+        from .workflow_runner import WorkflowRunner
+
+        runner = WorkflowRunner()
+        result = runner.run_coordinated_workflows(
+            workflow_files=workflows,
+            coordination_mode=mode,
+            max_parallel=max_parallel,
+            total_budget=budget,
+            dry_run=dry_run,
+        )
+
+        state_dir = _ensure_state_dir()
+        summary = {
+            "coordination_id": result.coordination_id,
+            "success": result.success,
+            "total_tokens_used": result.total_tokens_used,
+            "total_execution_time": result.total_execution_time,
+            "parallel_efficiency": result.parallel_efficiency,
+            "conflicts_detected": result.conflicts_detected,
+            "workflows": {
+                name: {
+                    "success": r.success,
+                    "tokens_used": r.tokens_used,
+                    "steps_completed": r.steps_completed,
+                    "execution_time": r.execution_time,
+                    "error": r.error,
+                    "artifacts": r.artifacts,
+                }
+                for name, r in (result.workflow_results or {}).items()
+            },
+            "params": {
+                "mode": mode,
+                "max_parallel": max_parallel,
+                "budget": budget,
+                "dry_run": dry_run,
+                "input_files": [str(p) for p in workflows],
+            },
+        }
+
+        out_path = state_dir / f"{result.coordination_id}.json"
+        try:
+            import json
+
+            with out_path.open("w", encoding="utf-8") as f:
+                json.dump(summary, f, indent=2, default=_json_default)
+            console.print(f"[dim]Saved state: {out_path}[/dim]")
+        except Exception as e:
+            console.print(f"[yellow]Could not persist coordination state: {e}[/yellow]")
+
+        if result.success:
+            console.print(f"[green]{_symbol(True)} Coordination completed: {result.coordination_id}[/green]")
+        else:
+            if result.conflicts_detected:
+                for c in result.conflicts_detected:
+                    console.print(f"[red]- {c}[/red]")
+            console.print(f"[red]{_symbol(False)} Coordination failed: {result.coordination_id}[/red]")
+            raise typer.Exit(code=1)
+
+    except ImportError:
+        console.print("[red]Workflow runner not available[/red]")
+        raise typer.Exit(code=1)
+
+
+@coordination_app.command("plan")
+def coordination_plan(
+    workflows: List[Path] = typer.Argument(..., help="Workflow files to analyze"),
+    output: Path = typer.Option(
+        Path("coordination_plan.json"), "--output", help="Output file"
+    ),
+):
+    """Create coordination plan with conflict detection."""
+    try:
+        import json
+        import yaml
+        from dataclasses import asdict
+        from .coordination import WorkflowCoordinator
+
+        # Load workflows
+        loaded: List[Dict[str, Any]] = []
+        for wf in workflows:
+            with wf.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+                loaded.append(data)
+
+        coordinator = WorkflowCoordinator()
+        plan = coordinator.create_coordination_plan(loaded)
+
+        # Serialize plan safely (convert Enums)
+        def _enum_safe(obj: Any) -> Any:
+            d = asdict(obj)
+            # Best-effort enum conversion
+            def _fix(v):
+                try:
+                    import enum
+
+                    if isinstance(v, enum.Enum):
+                        return v.value
+                except Exception:
+                    pass
+                return v
+
+            for k, v in list(d.items()):
+                if isinstance(v, list):
+                    d[k] = [(_fix(x) if not isinstance(x, dict) else x) for x in v]
+                else:
+                    d[k] = _fix(v)
+            return d
+
+        plan_dict = _enum_safe(plan)
+        with output.open("w", encoding="utf-8") as f:
+            json.dump(plan_dict, f, indent=2, default=_json_default)
+        console.print(f"[green]{_symbol(True)} Plan written to {output}[/green]")
+    except Exception as e:
+        console.print(f"[red]{_symbol(False)} Failed to create plan: {e}[/red]")
+        raise typer.Exit(code=1)
+
+
+@coordination_app.command("status")
+def coordination_status(
+    coordination_id: str = typer.Argument(..., help="Coordination session ID"),
+):
+    """Show coordination session status from persisted state."""
+    try:
+        import json
+
+        state_file = _ensure_state_dir() / f"{coordination_id}.json"
+        if not state_file.exists():
+            console.print(f"[yellow]No state found for {coordination_id}[/yellow]")
+            raise typer.Exit(code=1)
+
+        with state_file.open("r", encoding="utf-8") as f:
+            state = json.load(f)
+
+        ok = bool(state.get("success"))
+        console.print(
+            f"[bold blue]Coordination {coordination_id}[/bold blue] - {'SUCCESS' if ok else 'FAILED'}"
+        )
+        console.print(
+            f"[dim]tokens={state.get('total_tokens_used', 0)}, time={state.get('total_execution_time', 0.0):.2f}s, efficiency={state.get('parallel_efficiency', 0.0):.2f}[/dim]"
+        )
+
+        conflicts = state.get("conflicts_detected") or []
+        if conflicts:
+            console.print("[red]Conflicts detected:[/red]")
+            for c in conflicts:
+                console.print(f"[red]- {c}[/red]")
+
+    except Exception as e:
+        console.print(f"[red]Error reading status: {e}[/red]")
+        raise typer.Exit(code=1)
+
+
+@coordination_app.command("cancel")
+def coordination_cancel(
+    coordination_id: str = typer.Argument(..., help="Coordination session ID"),
+):
+    """Cancel a running coordination session (cooperative)."""
+    try:
+        cancel_flag = _ensure_state_dir() / f"{coordination_id}.cancel"
+        cancel_flag.touch(exist_ok=True)
+        console.print(f"[yellow]Cancel flag written: {cancel_flag}[/yellow]")
+    except Exception as e:
+        console.print(f"[red]Failed to write cancel flag: {e}[/red]")
+        raise typer.Exit(code=1)
+
+
+@coordination_app.command("dashboard")
+def coordination_dashboard(
+    coordination_id: Optional[str] = typer.Option(
+        None, "--id", help="Specific coordination ID"
+    ),
+    refresh_seconds: int = typer.Option(5, "--refresh", help="Refresh interval seconds"),
+    iterations: int = typer.Option(0, "--iterations", help="Stop after N iterations (0=run)"),
+):
+    """Show a simple real-time dashboard from persisted state."""
+    try:
+        import json
+        import time
+        from rich.live import Live
+
+        state_dir = _ensure_state_dir()
+
+        def _latest_id() -> Optional[str]:
+            files = sorted(state_dir.glob("coord_*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+            return files[0].stem if files else None
+
+        coord_id = coordination_id or _latest_id()
+        if not coord_id:
+            console.print("[yellow]No coordination sessions found[/yellow]")
+            return
+
+        state_file = state_dir / f"{coord_id}.json"
+        if not state_file.exists():
+            console.print(f"[yellow]No state found for {coord_id}[/yellow]")
+            raise typer.Exit(code=1)
+
+        def render() -> Table:
+            table = Table(title=f"Coordination Dashboard - {coord_id}")
+            table.add_column("Workflow", style="cyan")
+            table.add_column("Success", style="green")
+            table.add_column("Tokens", style="magenta")
+            table.add_column("Steps", style="yellow")
+            table.add_column("Time (s)", style="blue")
+            table.add_column("Error", style="red")
+
+            try:
+                with state_file.open("r", encoding="utf-8") as f:
+                    state = json.load(f)
+            except Exception:
+                state = {}
+
+            workflows = (state.get("workflow_results") or {})
+            for name, w in workflows.items():
+                table.add_row(
+                    name,
+                    str(w.get("success")),
+                    str(w.get("tokens_used", 0)),
+                    str(w.get("steps_completed", 0)),
+                    f"{(w.get('execution_time') or 0.0):.2f}",
+                    (w.get("error") or ""),
+                )
+
+            return table
+
+        loops = 0
+        with Live(render(), refresh_per_second=4) as live:
+            while iterations <= 0 or loops < iterations:
+                time.sleep(max(refresh_seconds, 1))
+                live.update(render())
+                loops += 1
+
+    except Exception as e:
+        console.print(f"[red]Dashboard error: {e}[/red]")
+        raise typer.Exit(code=1)
+
+
+@coordination_app.command("report")
+def coordination_report(
+    coordination_id: str = typer.Argument(..., help="Coordination session ID"),
+    format: str = typer.Option("json", "--format", help="Report format (json/html/csv)"),
+    output: Optional[Path] = typer.Option(
+        None, "--output", help="Output file (defaults to artifacts/reports)"
+    ),
+):
+    """Generate a simple coordination report."""
+    try:
+        import json
+        import csv
+
+        state_file = _ensure_state_dir() / f"{coordination_id}.json"
+        if not state_file.exists():
+            console.print(f"[yellow]No state found for {coordination_id}[/yellow]")
+            raise typer.Exit(code=1)
+
+        with state_file.open("r", encoding="utf-8") as f:
+            state = json.load(f)
+
+        out_dir = Path("artifacts/reports")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        fmt = format.lower()
+        out_path = output or out_dir / f"{coordination_id}.{fmt}"
+
+        if fmt == "json":
+            with out_path.open("w", encoding="utf-8") as f:
+                json.dump(state, f, indent=2, default=_json_default)
+        elif fmt == "csv":
+            with out_path.open("w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(["workflow", "success", "tokens_used", "steps_completed", "execution_time", "error"])
+                for name, w in (state.get("workflow_results") or {}).items():
+                    writer.writerow([
+                        name,
+                        w.get("success"),
+                        w.get("tokens_used", 0),
+                        w.get("steps_completed", 0),
+                        w.get("execution_time", 0.0),
+                        (w.get("error") or ""),
+                    ])
+        elif fmt == "html":
+            rows = []
+            for name, w in (state.get("workflow_results") or {}).items():
+                rows.append(
+                    f"<tr><td>{name}</td><td>{w.get('success')}</td><td>{w.get('tokens_used',0)}</td><td>{w.get('steps_completed',0)}</td><td>{w.get('execution_time',0.0)}</td><td>{(w.get('error') or '')}</td></tr>"
+                )
+            html = f"""
+<!doctype html>
+<html><head><meta charset='utf-8'><title>{coordination_id} Report</title>
+<style>table{{border-collapse:collapse}}td,th{{border:1px solid #ccc;padding:4px}}</style></head>
+<body>
+<h1>Coordination Report - {coordination_id}</h1>
+<p>Status: {'SUCCESS' if state.get('success') else 'FAILED'}</p>
+<p>Tokens: {state.get('total_tokens_used',0)} | Time: {state.get('total_execution_time',0.0)}s | Efficiency: {state.get('parallel_efficiency',0.0):.2f}</p>
+<table><thead><tr><th>Workflow</th><th>Success</th><th>Tokens</th><th>Steps</th><th>Time(s)</th><th>Error</th></tr></thead>
+<tbody>
+{''.join(rows)}
+</tbody></table>
+</body></html>
+"""
+            with out_path.open("w", encoding="utf-8") as f:
+                f.write(html)
+        else:
+            console.print(f"[red]Unknown format: {format}[/red]")
+            raise typer.Exit(code=1)
+
+        console.print(f"[green]{_symbol(True)} Report written to {out_path}[/green]")
+    except Exception as e:
+        console.print(f"[red]Report error: {e}[/red]")
+        raise typer.Exit(code=1)
+
+
+@coordination_app.command("history")
+def coordination_history(
+    days: int = typer.Option(7, "--days", help="Days of history to show"),
+    workflow_filter: Optional[str] = typer.Option(None, "--workflow", help="Filter by workflow name contains"),
+):
+    """Show recent coordination sessions from persisted state."""
+    try:
+        import json
+        import time
+
+        since = time.time() - days * 24 * 3600
+        state_dir = _ensure_state_dir()
+        files = sorted(state_dir.glob("coord_*.json"), key=lambda p: p.stat().st_mtime, reverse=True)
+        shown = 0
+        for f in files:
+            if f.stat().st_mtime < since:
+                continue
+            with f.open("r", encoding="utf-8") as fh:
+                state = json.load(fh)
+
+            if workflow_filter:
+                wfs = state.get("workflow_results") or {}
+                if not any(workflow_filter.lower() in name.lower() for name in wfs.keys()):
+                    continue
+
+            status = "SUCCESS" if state.get("success") else "FAILED"
+            console.print(f"{f.stem}  {status}  tokens={state.get('total_tokens_used',0)} time={state.get('total_execution_time',0.0):.2f}s")
+            shown += 1
+
+        if shown == 0:
+            console.print("[yellow]No sessions found in the requested window[/yellow]")
+    except Exception as e:
+        console.print(f"[red]History error: {e}[/red]")
+        raise typer.Exit(code=1)
 
 # Tools command group
 tools_app = typer.Typer(name="tools", help="Tool management commands")

--- a/src/cli_multi_rapid/router.py
+++ b/src/cli_multi_rapid/router.py
@@ -130,8 +130,10 @@ class Router:
         self.registry.register(SecurityScannerAdapter())
         self.registry.register(CertificateGeneratorAdapter())
 
-        # TODO: Register additional adapters:
-        # - verifier (quality gates)
+        # Register verifier adapter (quality gates)
+        from .adapters.verifier_adapter import VerifierAdapter
+
+        self.registry.register(VerifierAdapter())
 
         self.console.print(
             f"[dim]Initialized {len(self.registry.list_adapters())} adapters[/dim]"


### PR DESCRIPTION
This PR completes the multi-agent coordination plan by:

Highlights
- Adds coordination CLI group: un, plan, status, cancel, dashboard, eport, history.
- Persists coordination state to state/coordination/<id>.json; cooperative cancel via <id>.cancel.
- Adds esume_coordination(id) scaffolding in the runner.
- Adds VerifierAdapter and registers it in the router for quality gates.
- Loads defaults from .ai/config/coordination.yaml (mode, parallelism, budget, limits).
- Generates reports (json/html/csv) and a simple live dashboard.
- Makes runner outputs Windows-safe (avoid Unicode checkmarks).

Files
- New: src/cli_multi_rapid/adapters/verifier_adapter.py
- New: src/cli_multi_rapid/config/coordination.py
- Updated: src/cli_multi_rapid/main.py, src/cli_multi_rapid/workflow_runner.py, src/cli_multi_rapid/router.py, .gitignore

Usage
- Plan: cli-orchestrator coordination plan .ai/workflows/CODE_QUALITY.yaml --output artifacts/plan.json
- Run (dry): cli-orchestrator coordination run .ai/workflows/CODE_QUALITY.yaml --mode parallel --max-parallel 3 --budget 40 --dry-run
- Status: cli-orchestrator coordination status <coord_id>
- Cancel: cli-orchestrator coordination cancel <coord_id>
- Dashboard: cli-orchestrator coordination dashboard --iterations 1 --id <coord_id>
- Report: cli-orchestrator coordination report <coord_id> --format json|csv|html
- History: cli-orchestrator coordination history --days 7

Notes
- .ai/config/coordination.yaml is optional; sensible defaults are applied.
- state/coordination/ is git-ignored.
- Live dashboard reads persisted state; for richer telemetry we can integrate the event bus later.

Testing
- Smoke-tested plan/run/report/history locally (dry-run paths) with PYTHONPATH set to src.
- Next: add unit tests for CLI commands and state persistence to keep coverage ≥ 85%.